### PR TITLE
Rewriting DrawBoard

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@nanostores/persistent": "^0.5.3",
     "@nanostores/solid": "^0.1.6",
     "@solid-primitives/raf": "^2.1.0",
+    "@solid-primitives/resize-observer": "^2.0.2",
     "@solid-primitives/utils": "^2.2.1",
     "@suid/icons-material": "^0.2.5",
     "@suid/material": "^0.4.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,10 @@ const ErrorPage = lazy(() => import("./pages/ErrorPage"));
 const DevDrawBroad = lazy(() => import("./pages/DevDrawBroad"));
 const DevMesh = lazy(() => import("./pages/DevMesh"));
 
+const DEV_PAGES = {
+    DrawBoard: lazy(() => import("./pages/dev/DrawBoardPage"))
+};
+
 const App: Component = () => {
     return (<>
         <CssBaseline />
@@ -28,6 +32,9 @@ const App: Component = () => {
             <Route path="/dev-draw-broad" element={<DevDrawBroad />} />
             <Route path="/rooms/:id" element={<Room />} />
             <Route path="/dev-mesh" element={<DevMesh />} />
+            <Route path="/_dev">
+                <Route path="/draw-board" element={<DEV_PAGES.DrawBoard />} />
+            </Route>
             <Route path="/*" element={<ErrorPage httpErrCode={404} />} />
         </Routes>
     </>);

--- a/src/pages/dev/DrawBoardPage.tsx
+++ b/src/pages/dev/DrawBoardPage.tsx
@@ -1,0 +1,265 @@
+import AppBar from "@suid/material/AppBar";
+import Box from "@suid/material/Box";
+import Toolbar from "@suid/material/Toolbar";
+import Typography from "@suid/material/Typography";
+import Popper, { PopperProps } from "@suid/material/Popper";
+import { Accessor, Component, For, JSX, Setter, Show, createEffect, createSignal, onCleanup, onMount } from "solid-js";
+import { DrawBoard } from "../../widgets/DrawBroad/board";
+import Paper from "@suid/material/Paper";
+import CloseIcon from "@suid/icons-material/Close";
+import Button from "@suid/material/Button";
+import IconButton from "@suid/material/IconButton";
+import MoreVertIcon from "@suid/icons-material/MoreVert";
+import Popover from "@suid/material/Popover";
+import List from "@suid/material/List";
+import ListItem from "@suid/material/ListItem";
+import ListItemButton from "@suid/material/ListItemButton";
+import ListItemIcon from "@suid/material/ListItemIcon";
+import Checkbox from "@suid/material/Checkbox";
+import ListItemText from "@suid/material/ListItemText";
+import Divider from "@suid/material/Divider";
+import TextField from "@suid/material/TextField";
+
+interface OverlayWindowProps {
+    id: string,
+    title?: string,
+    open: boolean,
+    children?: JSX.Element,
+    position: {x: number, y: number},
+    onClose?: ((event: Record<string, never>) => void),
+    onPositionChanging?: ((newPosition: {x: number, y: number}) => void),
+}
+
+const OverlayWindow: Component<OverlayWindowProps> = (props) => {
+    const [anchorEl, setAnchorEl] = createSignal<PopperProps["anchorEl"]>(null);
+
+    const getId = () => (props.open ? props.id : undefined);
+
+    const onMouseMoving = (event: MouseEvent) => {
+        if (props.onPositionChanging) {
+            props.onPositionChanging({
+                x: event.pageX,
+                y: event.pageY - 12,
+            });
+        }
+    };
+
+    createEffect(() => {
+        const {x, y} = props.position;
+        const object = {
+            width: 0,
+            height: 0,
+            top: y,
+            right: x,
+            bottom: y,
+            left: x,
+            x: x,
+            y: y,
+            toJSON: () => {
+                return object;
+            },
+        };
+        setAnchorEl({
+            getBoundingClientRect: () => object,
+        });
+    });
+
+    return <Popper
+        id={getId()}
+        open={props.open}
+        anchorEl={anchorEl()}
+    >
+        <Paper elevation={3}>
+            <Box
+                sx={{
+                    height: "24px",
+                    width: "100%",
+                    minWidth: "240px",
+                    display: "flex",
+                    cursor: "move",
+                }}
+                backgroundColor="primary.light"
+                onMouseDown={() => {
+                    document.addEventListener("mousemove", onMouseMoving);
+                }}
+                onMouseUp={() => {
+                    document.removeEventListener("mousemove", onMouseMoving);
+                }}
+            >
+                <Typography component="div" sx={{flexGrow: 1, userSelect: "none"}} color="inherit">{props.title? props.title: ""}</Typography>
+                <Show when={!!props.onClose}>
+                    <Button
+                        variant="text"
+                        disableRipple
+                        disableFocusRipple
+                        disableTouchRipple
+                        disableElevation
+                        color="inherit"
+                        sx={{minWidth: undefined, height: "24px", width: "24px"}}
+                        onClick={() => {
+                            if (props.onClose) {
+                                props.onClose({});
+                            }
+                        }}
+                    ><CloseIcon /></Button>
+                </Show>
+            </Box>
+            {props.children}
+        </Paper>
+    </Popper>;
+};
+
+class OverlayWindowState {
+    open: Accessor<boolean>;
+    setOpen: Setter<boolean>;
+    title: Accessor<string | undefined>;
+    setTitle: Setter<string | undefined>;
+    position: Accessor<{x: number, y: number}>;
+    setPosition: Setter<{x: number, y: number}>;
+
+    constructor(defauleTitle?: string, defaultOpen = false, defaultPosition = {x: window.innerWidth / 2, y: window.innerHeight / 2}) {
+        const [open, setOpen] = createSignal<boolean>(defaultOpen);
+        this.open = open;
+        this.setOpen = setOpen;
+        const [title, setTitle] = createSignal<string | undefined>(defauleTitle);
+        this.title = title;
+        this.setTitle = setTitle;
+        const [position, setPosition] = createSignal<{x: number, y: number}>(defaultPosition);
+        this.position = position;
+        this.setPosition = setPosition;
+    }
+}
+
+interface StatefulOverlayWindow {
+    id: string,
+    state: OverlayWindowState,
+    children?: JSX.Element,
+}
+
+const StatefulOverlayWindow: Component<StatefulOverlayWindow> = (props) => {
+    return <OverlayWindow
+        id={props.id}
+        open={props.state.open()}
+        title={props.state.title()}
+        position={props.state.position()}
+        onPositionChanging={(pos) => props.state.setPosition(pos)}
+        onClose={() => props.state.setOpen(false)}
+    >{props.children}</OverlayWindow>;
+};
+
+const DrawBoardPage: Component = () => {
+    const [isMoreMenuOpen, setIsMoreMenuOpen] = createSignal<boolean>(false);
+    const [boardSize, setBoardSize] = createSignal<{w: number, h: number}>({w: 0, h: 0});
+
+    let moreIconButtonRef: HTMLButtonElement;
+
+    const board = new DrawBoard(document.createElement("canvas"));
+    const boardConfigWindowState = new OverlayWindowState("DrawBoard Config");
+
+    const onBoardResized = (event: Event) => {
+        const target = (event.target as HTMLCanvasElement);
+        setBoardSize({
+            w: target.width,
+            h: target.height,
+        });
+    };
+
+    const applyBoardSize = () => {
+        const {w, h} = boardSize();
+        board.offscreen.width = w;
+        board.offscreen.height = h;
+        setBoardSize({w, h}); // make sure buttons' disabling are applied
+    };
+
+    const isConfigBoardSizeEqualsTheActual = () => {
+        const size = boardSize();
+        return (size.w === board.offscreen.width) && (size.h === board.offscreen.height);
+    };
+
+    onMount(() => {
+        board.offscreen.addEventListener("resize", onBoardResized);
+        setBoardSize({w: board.offscreen.width, h: board.offscreen.height});
+    });
+
+    onCleanup(() => {
+        board.offscreen.removeEventListener("resize", onBoardResized);
+    });
+
+    return <Box sx={{flexGrow: 1}}>
+        <AppBar position="static">
+            <Toolbar>
+                <Typography variant="h6" component="div" sx={{flexGrow: 1}}>
+                    New DrawBoard Testing Page
+                </Typography>
+                <IconButton
+                    // @ts-expect-error: this value will be assigned before onMount
+                    ref={moreIconButtonRef}
+                    color="inherit"
+                    onClick={() => setIsMoreMenuOpen(true)}>
+                    <MoreVertIcon />
+                </IconButton>
+                <Popover
+                    // @ts-expect-error: this value will be assigned before onMount
+                    anchorEl={moreIconButtonRef}
+                    open={isMoreMenuOpen()}
+                    onClose={() => setIsMoreMenuOpen(false)}>
+                    <Typography sx={{padding: "8px"}}>Available windows</Typography>
+                    <Divider />
+                    <List disablePadding>
+                        <For each={[boardConfigWindowState]}>
+                            {(state) => <ListItem disablePadding>
+                                <ListItemButton onClick={() => state.setOpen(prev => !prev)}>
+                                    <ListItemIcon><Checkbox checked={state.open()}/></ListItemIcon>
+                                    <ListItemText primary={state.title()}></ListItemText>
+                                </ListItemButton>
+                            </ListItem>}
+                        </For>
+                        
+                    </List>
+                </Popover>
+            </Toolbar>
+        </AppBar>
+
+        <StatefulOverlayWindow id="draw-board-config" state={boardConfigWindowState}>
+            <Box sx={{padding: "24px"}}>
+                <TextField
+                    sx={{padding: "2px"}}
+                    label="width"
+                    variant="standard"
+                    value={boardSize().w.toString()}
+                    onChange={
+                        event => 
+                            setBoardSize(
+                                ({h}) => ({w: new Number(event.target.value).valueOf(), h})
+                            )
+                    }
+                />
+                <TextField
+                    sx={{padding: "2px"}}
+                    label="height"
+                    variant="standard"
+                    value={boardSize().h.toString()}
+                    onChange={
+                        event => {
+                            setBoardSize(
+                                ({w}) => ({w, h: new Number(event.target.value).valueOf()})
+                            );
+                        }
+                    }
+                />
+                <Box sx={{display: "flex"}}>
+                    <Button onClick={() => {
+                        setBoardSize({
+                            w: board.offscreen.width,
+                            h: board.offscreen.height,
+                        });
+                    }} disabled={isConfigBoardSizeEqualsTheActual()}>Cancel Changes</Button>
+                    <Box sx={{flexGrow: 1}} />
+                    <Button onClick={applyBoardSize} disabled={isConfigBoardSizeEqualsTheActual()}>Apply</Button>
+                </Box>
+            </Box>
+        </StatefulOverlayWindow>
+    </Box>;
+};
+
+export default DrawBoardPage;

--- a/src/pages/dev/DrawBoardPage.tsx
+++ b/src/pages/dev/DrawBoardPage.tsx
@@ -20,6 +20,9 @@ import ListItemText from "@suid/material/ListItemText";
 import Divider from "@suid/material/Divider";
 import TextField from "@suid/material/TextField";
 
+import {DrawBoardView} from "../../widgets/DrawBroad/solid";
+import ScrollbarController from "../../widgets/DrawBroad/ScrollbarController";
+
 interface OverlayWindowProps {
     id: string,
     title?: string,
@@ -155,6 +158,9 @@ const DrawBoardPage: Component = () => {
 
     const board = new DrawBoard(document.createElement("canvas"));
     const boardConfigWindowState = new OverlayWindowState("DrawBoard Config");
+    const boardSampleDrawingWindowState = new OverlayWindowState("Sample Drawings");
+
+    const scrollCtl = new ScrollbarController();
 
     const onBoardResized = (event: Event) => {
         const target = (event.target as HTMLCanvasElement);
@@ -176,9 +182,24 @@ const DrawBoardPage: Component = () => {
         return (size.w === board.offscreen.width) && (size.h === board.offscreen.height);
     };
 
+    const applySampleDrawing = () => {
+        const pen = board.getPen();
+        const points = [
+            { x: 100, y: 100 },
+            { x: 150, y: 150 },
+            { x: 200, y: 200 },
+            { x: 250, y: 250 },
+            { x: 250, y: 100 },
+            { x: 100, y: 100 },
+        ];
+        for (const point of points) {
+            pen.addPoint({ color: "black", lineWidth: 40, ...point });
+        }
+    };
+
     onMount(() => {
         board.offscreen.addEventListener("resize", onBoardResized);
-        setBoardSize({w: board.offscreen.width, h: board.offscreen.height});
+        setBoardSize({ w: board.offscreen.width, h: board.offscreen.height });
     });
 
     onCleanup(() => {
@@ -206,11 +227,11 @@ const DrawBoardPage: Component = () => {
                     <Typography sx={{padding: "8px"}}>Available windows</Typography>
                     <Divider />
                     <List disablePadding>
-                        <For each={[boardConfigWindowState]}>
+                        <For each={[boardConfigWindowState, boardSampleDrawingWindowState]}>
                             {(state) => <ListItem disablePadding>
                                 <ListItemButton onClick={() => state.setOpen(prev => !prev)}>
                                     <ListItemIcon><Checkbox checked={state.open()}/></ListItemIcon>
-                                    <ListItemText primary={state.title()}></ListItemText>
+                                    <ListItemText primary={state.title()} />
                                 </ListItemButton>
                             </ListItem>}
                         </For>
@@ -220,6 +241,10 @@ const DrawBoardPage: Component = () => {
             </Toolbar>
         </AppBar>
 
+        <Box>
+            <DrawBoardView board={board} scrollCtl={scrollCtl} />
+        </Box>
+        
         <StatefulOverlayWindow id="draw-board-config" state={boardConfigWindowState}>
             <Box sx={{padding: "24px"}}>
                 <TextField
@@ -257,6 +282,15 @@ const DrawBoardPage: Component = () => {
                     <Box sx={{flexGrow: 1}} />
                     <Button onClick={applyBoardSize} disabled={isConfigBoardSizeEqualsTheActual()}>Apply</Button>
                 </Box>
+            </Box>
+        </StatefulOverlayWindow>
+
+        <StatefulOverlayWindow id="draw-board-sample-drawings" state={boardSampleDrawingWindowState}>
+            <Box sx={{ padding: "24px" }}>
+                <List>
+                    <ListItemButton onClick={() => board.reset()}><Typography>Clear</Typography></ListItemButton>
+                    <ListItemButton onClick={() => applySampleDrawing()}><Typography>Basic</Typography></ListItemButton>
+                </List>
             </Box>
         </StatefulOverlayWindow>
     </Box>;

--- a/src/pages/dev/DrawBoardPage.tsx
+++ b/src/pages/dev/DrawBoardPage.tsx
@@ -20,16 +20,20 @@ import TextField from "@suid/material/TextField";
 import {DrawBoardView} from "../../widgets/DrawBroad/solid";
 import ScrollbarController from "../../widgets/DrawBroad/ScrollbarController";
 import { OverlayWindowState, StatefulOverlayWindow } from "../../widgets/overlay_windows";
+import ListItemSecondaryAction from "@suid/material/ListItemSecondaryAction";
+import Switch from "@suid/material/Switch";
 
 const DrawBoardPage: Component = () => {
     const [isMoreMenuOpen, setIsMoreMenuOpen] = createSignal<boolean>(false);
-    const [boardSize, setBoardSize] = createSignal<{w: number, h: number}>({w: 0, h: 0});
+    const [boardSize, setBoardSize] = createSignal<{ w: number, h: number }>({ w: 0, h: 0 });
+    const [viewOutlineEnabled, setViewOutlineEnabled] = createSignal<boolean>(false);
 
     let moreIconButtonRef: HTMLButtonElement;
 
     const board = new DrawBoard(document.createElement("canvas"));
     const boardConfigWindowState = new OverlayWindowState("DrawBoard Config");
     const boardSampleDrawingWindowState = new OverlayWindowState("Sample Drawings");
+    const boardViewConfigWindowState = new OverlayWindowState("DrawBoardView Config");
 
     const scrollCtl = new ScrollbarController();
 
@@ -98,7 +102,7 @@ const DrawBoardPage: Component = () => {
                     <Typography sx={{padding: "8px"}}>Available windows</Typography>
                     <Divider />
                     <List disablePadding>
-                        <For each={[boardConfigWindowState, boardSampleDrawingWindowState]}>
+                        <For each={[boardConfigWindowState, boardSampleDrawingWindowState, boardViewConfigWindowState]}>
                             {(state) => <ListItem disablePadding>
                                 <ListItemButton onClick={() => state.setOpen(prev => !prev)}>
                                     <ListItemIcon><Checkbox checked={state.open()}/></ListItemIcon>
@@ -112,7 +116,9 @@ const DrawBoardPage: Component = () => {
             </Toolbar>
         </AppBar>
 
-        <Box>
+        <Box sx={{
+            outline: viewOutlineEnabled() ? "dashed red 2px" : undefined
+        }}>
             <DrawBoardView board={board} scrollCtl={scrollCtl} />
         </Box>
         
@@ -161,6 +167,23 @@ const DrawBoardPage: Component = () => {
                 <List>
                     <ListItemButton onClick={() => board.reset()}><Typography>Clear</Typography></ListItemButton>
                     <ListItemButton onClick={() => applySampleDrawing()}><Typography>Basic</Typography></ListItemButton>
+                </List>
+            </Box>
+        </StatefulOverlayWindow>
+
+        <StatefulOverlayWindow id="draw-board-view-config" state={boardViewConfigWindowState}>
+            <Box>
+                <List>
+                    <ListItem>
+                        <Typography>Outline</Typography>
+                        <ListItemSecondaryAction>
+                            <Switch
+                                value={viewOutlineEnabled()}
+                                onChange={
+                                    (ev, val) => setViewOutlineEnabled(val)
+                                } />
+                        </ListItemSecondaryAction>
+                    </ListItem>
                 </List>
             </Box>
         </StatefulOverlayWindow>

--- a/src/pages/dev/DrawBoardPage.tsx
+++ b/src/pages/dev/DrawBoardPage.tsx
@@ -2,11 +2,8 @@ import AppBar from "@suid/material/AppBar";
 import Box from "@suid/material/Box";
 import Toolbar from "@suid/material/Toolbar";
 import Typography from "@suid/material/Typography";
-import Popper, { PopperProps } from "@suid/material/Popper";
-import { Accessor, Component, For, JSX, Setter, Show, createEffect, createSignal, onCleanup, onMount } from "solid-js";
+import { Component, For, createSignal, onCleanup, onMount } from "solid-js";
 import { DrawBoard } from "../../widgets/DrawBroad/board";
-import Paper from "@suid/material/Paper";
-import CloseIcon from "@suid/icons-material/Close";
 import Button from "@suid/material/Button";
 import IconButton from "@suid/material/IconButton";
 import MoreVertIcon from "@suid/icons-material/MoreVert";
@@ -22,133 +19,7 @@ import TextField from "@suid/material/TextField";
 
 import {DrawBoardView} from "../../widgets/DrawBroad/solid";
 import ScrollbarController from "../../widgets/DrawBroad/ScrollbarController";
-
-interface OverlayWindowProps {
-    id: string,
-    title?: string,
-    open: boolean,
-    children?: JSX.Element,
-    position: {x: number, y: number},
-    onClose?: ((event: Record<string, never>) => void),
-    onPositionChanging?: ((newPosition: {x: number, y: number}) => void),
-}
-
-const OverlayWindow: Component<OverlayWindowProps> = (props) => {
-    const [anchorEl, setAnchorEl] = createSignal<PopperProps["anchorEl"]>(null);
-
-    const getId = () => (props.open ? props.id : undefined);
-
-    const onMouseMoving = (event: MouseEvent) => {
-        if (props.onPositionChanging) {
-            props.onPositionChanging({
-                x: event.pageX,
-                y: event.pageY - 12,
-            });
-        }
-    };
-
-    createEffect(() => {
-        const {x, y} = props.position;
-        const object = {
-            width: 0,
-            height: 0,
-            top: y,
-            right: x,
-            bottom: y,
-            left: x,
-            x: x,
-            y: y,
-            toJSON: () => {
-                return object;
-            },
-        };
-        setAnchorEl({
-            getBoundingClientRect: () => object,
-        });
-    });
-
-    return <Popper
-        id={getId()}
-        open={props.open}
-        anchorEl={anchorEl()}
-    >
-        <Paper elevation={3}>
-            <Box
-                sx={{
-                    height: "24px",
-                    width: "100%",
-                    minWidth: "240px",
-                    display: "flex",
-                    cursor: "move",
-                }}
-                backgroundColor="primary.light"
-                onMouseDown={() => {
-                    document.addEventListener("mousemove", onMouseMoving);
-                }}
-                onMouseUp={() => {
-                    document.removeEventListener("mousemove", onMouseMoving);
-                }}
-            >
-                <Typography component="div" sx={{flexGrow: 1, userSelect: "none"}} color="inherit">{props.title? props.title: ""}</Typography>
-                <Show when={!!props.onClose}>
-                    <Button
-                        variant="text"
-                        disableRipple
-                        disableFocusRipple
-                        disableTouchRipple
-                        disableElevation
-                        color="inherit"
-                        sx={{minWidth: undefined, height: "24px", width: "24px"}}
-                        onClick={() => {
-                            if (props.onClose) {
-                                props.onClose({});
-                            }
-                        }}
-                    ><CloseIcon /></Button>
-                </Show>
-            </Box>
-            {props.children}
-        </Paper>
-    </Popper>;
-};
-
-class OverlayWindowState {
-    open: Accessor<boolean>;
-    setOpen: Setter<boolean>;
-    title: Accessor<string | undefined>;
-    setTitle: Setter<string | undefined>;
-    position: Accessor<{x: number, y: number}>;
-    setPosition: Setter<{x: number, y: number}>;
-
-    constructor(defauleTitle?: string, defaultOpen = false, defaultPosition = {x: window.innerWidth / 2, y: window.innerHeight / 2}) {
-        const [open, setOpen] = createSignal<boolean>(defaultOpen);
-        this.open = open;
-        this.setOpen = setOpen;
-        const [title, setTitle] = createSignal<string | undefined>(defauleTitle);
-        this.title = title;
-        this.setTitle = setTitle;
-        const [position, setPosition] = createSignal<{x: number, y: number}>(defaultPosition);
-        this.position = position;
-        this.setPosition = setPosition;
-    }
-}
-
-interface StatefulOverlayWindow {
-    id: string,
-    state: OverlayWindowState,
-    children?: JSX.Element,
-}
-
-const StatefulOverlayWindow: Component<StatefulOverlayWindow> = (props) => {
-    return <OverlayWindow
-        id={props.id}
-        open={props.state.open()}
-        title={props.state.title()}
-        position={props.state.position()}
-        onPositionChanging={(pos) => props.state.setPosition(pos)}
-        onClose={() => props.state.setOpen(false)}
-    >{props.children}</OverlayWindow>;
-};
+import { OverlayWindowState, StatefulOverlayWindow } from "../../widgets/overlay_windows";
 
 const DrawBoardPage: Component = () => {
     const [isMoreMenuOpen, setIsMoreMenuOpen] = createSignal<boolean>(false);

--- a/src/widgets/DrawBroad/board.ts
+++ b/src/widgets/DrawBroad/board.ts
@@ -37,6 +37,7 @@ export interface UpdatedArea {
     y: number,
     w: number,
     h: number,
+    redraw: boolean,
 }
 
 export class DrawBoard {
@@ -57,7 +58,7 @@ export class DrawBoard {
         const width = this.offscreen.width;
         const height = this.offscreen.height;
         this.ctx2d.clearRect(0, 0, width, height);
-        this.setUpdated({x: 0, y: 0, w: width, h: height});
+        this.setUpdated({x: 0, y: 0, w: width, h: height, redraw: true});
     }
 
     setUpdated(updatedArea?: UpdatedArea) {

--- a/src/widgets/DrawBroad/board.ts
+++ b/src/widgets/DrawBroad/board.ts
@@ -1,0 +1,104 @@
+
+export interface DrawPoint {
+    x: number,
+    y: number,
+    lineWidth: number,
+    color: string,
+}
+
+export class DrawPen {
+    stroke: DrawPoint[];
+    doDraw: ((stroke: DrawPoint[]) => void);
+    onUpdated?: ((stroke: DrawPoint[]) => void);
+
+    constructor(doDraw: ((stroke: DrawPoint[]) => void)) {
+        this.stroke = [];
+        this.doDraw = doDraw;
+    }
+
+    clear() {
+        this.stroke = [];
+        if (this.onUpdated) {
+            this.onUpdated(this.stroke);
+        }
+    }
+
+    addPoint(point: DrawPoint) {
+        this.stroke.push(point);
+        this.doDraw(this.stroke);
+        if (this.onUpdated) {
+            this.onUpdated(this.stroke);
+        }
+    }
+}
+
+export interface UpdatedArea {
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+}
+
+export class DrawBoard {
+    offscreen: HTMLCanvasElement;
+    ctx2d: CanvasRenderingContext2D;
+    onUpdated?: (board: DrawBoard, area?: UpdatedArea) => void;
+
+    constructor(offscreen: HTMLCanvasElement) {
+        this.offscreen = offscreen;
+        const ctx2d = this.offscreen.getContext("2d");
+        if (!ctx2d) {
+            throw new Error("unable get 2d context");
+        }
+        this.ctx2d = ctx2d;
+    }
+
+    reset() {
+        const width = this.offscreen.width;
+        const height = this.offscreen.height;
+        this.ctx2d.clearRect(0, 0, width, height);
+        this.setUpdated({x: 0, y: 0, w: width, h: height});
+    }
+
+    setUpdated(updatedArea?: UpdatedArea) {
+        if (this.onUpdated) {
+            this.onUpdated(this, updatedArea);
+        }
+    }
+
+    draw(stroke: DrawPoint[]) {
+        const context = this.ctx2d;
+        context.lineCap = "round";
+        context.lineJoin = "round";
+        if (stroke.length <= 0) {
+            return;
+        }
+      
+        const l = stroke.length - 1;
+        if (stroke.length >= 3) {
+            const lastX = (stroke[l-1].x + stroke[l-2].x) / 2;
+            const lastY = (stroke[l-1].y + stroke[l-2].y) / 2;
+            context.beginPath();
+            context.moveTo(lastX, lastY);
+            const xc = (stroke[l].x + stroke[l - 1].x) / 2;
+            const yc = (stroke[l].y + stroke[l - 1].y) / 2;
+            context.lineWidth = stroke[l - 1].lineWidth;
+            context.quadraticCurveTo(stroke[l - 1].x, stroke[l - 1].y, xc, yc);
+            context.strokeStyle = stroke[l].color;
+            context.stroke();
+        } else {
+            const point = stroke[l];
+            context.lineWidth = point.lineWidth;
+            context.strokeStyle = point.color;
+            context.beginPath();
+            context.moveTo(point.x, point.y);
+            context.stroke();
+        }
+
+        this.setUpdated(); // TODO: partial update
+    }
+
+    getPen(): DrawPen {
+        return new DrawPen((stroke) => this.draw(stroke));
+    }
+}

--- a/src/widgets/DrawBroad/solid.tsx
+++ b/src/widgets/DrawBroad/solid.tsx
@@ -1,0 +1,119 @@
+import createRAF from "@solid-primitives/raf";
+import { Component, JSX, onCleanup, onMount } from "solid-js";
+import type { DrawBoard, UpdatedArea } from "./board";
+import ScrollbarController from "./ScrollbarController";
+import { createResizeObserver } from "@solid-primitives/resize-observer";
+
+interface DrawBoardViewProps {
+    board: DrawBoard,
+    scrollCtl: ScrollbarController,
+    style?: string | JSX.CSSProperties,
+}
+
+const mergeUpdatedArea = (u0: UpdatedArea, u1: UpdatedArea): UpdatedArea => {
+    return {
+        x: Math.min(u0.x, u0.x),
+        y: Math.min(u0.y, u1.y),
+        w: Math.max(u0.w, u1.w),
+        h: Math.max(u0.h, u1.h),
+    };
+};
+
+export const DrawBoardView: Component<DrawBoardViewProps> = (p) => {
+    let element!: HTMLCanvasElement;
+    let rootElement!: HTMLDivElement;
+    let ctx2d: CanvasRenderingContext2D | undefined;
+
+    let isBufferDirty = false;
+    let bufferDirtyArea: undefined | UpdatedArea;
+    let isRedrawingNeeded = false;
+
+    const onDrawBoardUpdated = (board: DrawBoard, updated?: UpdatedArea) => {
+        isBufferDirty = false;
+        if (updated) {
+            bufferDirtyArea = typeof bufferDirtyArea !== "undefined"? mergeUpdatedArea(updated, bufferDirtyArea) : updated;
+        }
+        isBufferDirty = true;
+        console.log("update area", bufferDirtyArea);
+    };
+
+    const synchronise = (dirtyArea?: UpdatedArea) => {
+        if (!ctx2d) return;
+
+        if (isRedrawingNeeded) {
+            ctx2d.clearRect(0, 0, element.width, element.height);
+            isRedrawingNeeded = false;
+            dirtyArea = undefined; // ignore partial update
+        }
+
+        const srcX = dirtyArea ? dirtyArea.x : p.scrollCtl.getRangeX()[0];
+        const srcY = dirtyArea ? dirtyArea.y : p.scrollCtl.getRangeY()[0];
+        const srcW = dirtyArea ? Math.min(dirtyArea.w, element.width) : element.width;
+        const srcH = dirtyArea ? Math.min(dirtyArea.h, element.height): element.height;
+        const destX = dirtyArea ? dirtyArea.x - p.scrollCtl.getRangeX()[0] : 0;
+        const destY = dirtyArea ? dirtyArea.y - p.scrollCtl.getRangeY()[0]: 0;
+        const destW = dirtyArea ? Math.min(dirtyArea.w, element.width) : element.width;
+        const destH = dirtyArea ? Math.min(dirtyArea.h, element.height): element.height;
+
+        ctx2d.drawImage(
+            p.board.offscreen,
+            srcX,
+            srcY,
+            srcW,
+            srcH,
+            destX,
+            destY,
+            destW,
+            destH,
+        );
+    };
+
+    const [, bufferSyncStart, bufferSyncStop] = createRAF(() => (isBufferDirty ? synchronise(bufferDirtyArea) : undefined));
+
+    const updateScrollbarCtl = () => {
+        p.scrollCtl.setAxisX(p.board.offscreen.width, 0, Math.min(element.width, p.board.offscreen.width));
+        p.scrollCtl.setAxisY(p.board.offscreen.height, 0, Math.min(element.height, p.board.offscreen.height));
+        isBufferDirty = true;
+    };
+
+    onMount(() => {
+        if (typeof p.board.onUpdated !== "undefined") {
+            throw new Error("one DrawBoard only allow to attach to one DrawBoardView");
+        }
+        p.board.onUpdated = onDrawBoardUpdated;
+        const ctx = element.getContext("2d");
+        if (!ctx) {
+            throw new Error("unable to get 2d context");
+        }
+        ctx2d = ctx;
+
+        bufferSyncStart();
+    });
+
+    onMount(() => {
+        createResizeObserver(element, ({ width, height }) => {
+            element.width = width;
+            element.height = height;
+            
+            updateScrollbarCtl();
+        }, {
+            box: "device-pixel-content-box",
+        });
+    });
+
+    onCleanup(() => {
+        bufferSyncStop();
+        
+        p.board.onUpdated = undefined;
+    });
+
+    return <div ref={rootElement} style={p.style}>
+        <canvas style={{
+            position: "relative",
+            left: 0,
+            top: 0,
+            width: "100%",
+            height: "100%",
+        }} ref={element} />
+    </div>;
+};

--- a/src/widgets/DrawBroad/solid.tsx
+++ b/src/widgets/DrawBroad/solid.tsx
@@ -16,6 +16,7 @@ const mergeUpdatedArea = (u0: UpdatedArea, u1: UpdatedArea): UpdatedArea => {
         y: Math.min(u0.y, u1.y),
         w: Math.max(u0.w, u1.w),
         h: Math.max(u0.h, u1.h),
+        redraw: u0.redraw || u1.redraw,
     };
 };
 
@@ -34,7 +35,6 @@ export const DrawBoardView: Component<DrawBoardViewProps> = (p) => {
             bufferDirtyArea = typeof bufferDirtyArea !== "undefined"? mergeUpdatedArea(updated, bufferDirtyArea) : updated;
         }
         isBufferDirty = true;
-        console.log("update area", bufferDirtyArea);
     };
 
     const synchronise = (dirtyArea?: UpdatedArea) => {
@@ -53,7 +53,12 @@ export const DrawBoardView: Component<DrawBoardViewProps> = (p) => {
         const destX = dirtyArea ? dirtyArea.x - p.scrollCtl.getRangeX()[0] : 0;
         const destY = dirtyArea ? dirtyArea.y - p.scrollCtl.getRangeY()[0]: 0;
         const destW = dirtyArea ? Math.min(dirtyArea.w, element.width) : element.width;
-        const destH = dirtyArea ? Math.min(dirtyArea.h, element.height): element.height;
+        const destH = dirtyArea ? Math.min(dirtyArea.h, element.height) : element.height;
+        const redrawFlag = dirtyArea ? dirtyArea.redraw : false;
+
+        if (redrawFlag) {
+            ctx2d.clearRect(destX, destY, destW, destH);
+        }
 
         ctx2d.drawImage(
             p.board.offscreen,
@@ -66,6 +71,9 @@ export const DrawBoardView: Component<DrawBoardViewProps> = (p) => {
             destW,
             destH,
         );
+
+        isBufferDirty = false;
+        bufferDirtyArea = undefined;
     };
 
     const [, bufferSyncStart, bufferSyncStop] = createRAF(() => (isBufferDirty ? synchronise(bufferDirtyArea) : undefined));

--- a/src/widgets/overlay_windows.tsx
+++ b/src/widgets/overlay_windows.tsx
@@ -1,0 +1,134 @@
+import Box from "@suid/material/Box";
+import Button from "@suid/material/Button";
+import Paper from "@suid/material/Paper";
+import Popper, { PopperProps } from "@suid/material/Popper";
+import Typography from "@suid/material/Typography";
+import { Accessor, Component, JSX, Setter, Show, createEffect, createSignal } from "solid-js";
+import CloseIcon from "@suid/icons-material/Close";
+
+export interface OverlayWindowProps {
+    id: string,
+    title?: string,
+    open: boolean,
+    children?: JSX.Element,
+    position: {x: number, y: number},
+    onClose?: ((event: Record<string, never>) => void),
+    onPositionChanging?: ((newPosition: {x: number, y: number}) => void),
+}
+
+export const OverlayWindow: Component<OverlayWindowProps> = (props) => {
+    const [anchorEl, setAnchorEl] = createSignal<PopperProps["anchorEl"]>(null);
+
+    const getId = () => (props.open ? props.id : undefined);
+
+    const onMouseMoving = (event: MouseEvent) => {
+        if (props.onPositionChanging) {
+            props.onPositionChanging({
+                x: event.pageX,
+                y: event.pageY - 12,
+            });
+        }
+    };
+
+    createEffect(() => {
+        const {x, y} = props.position;
+        const object = {
+            width: 0,
+            height: 0,
+            top: y,
+            right: x,
+            bottom: y,
+            left: x,
+            x: x,
+            y: y,
+            toJSON: () => {
+                return object;
+            },
+        };
+        setAnchorEl({
+            getBoundingClientRect: () => object,
+        });
+    });
+
+    return <Popper
+        id={getId()}
+        open={props.open}
+        anchorEl={anchorEl()}
+    >
+        <Paper elevation={3}>
+            <Box
+                sx={{
+                    height: "24px",
+                    width: "100%",
+                    minWidth: "240px",
+                    display: "flex",
+                    cursor: "move",
+                }}
+                backgroundColor="primary.light"
+                onMouseDown={() => {
+                    document.addEventListener("mousemove", onMouseMoving);
+                }}
+                onMouseUp={() => {
+                    document.removeEventListener("mousemove", onMouseMoving);
+                }}
+            >
+                <Typography component="div" sx={{flexGrow: 1, userSelect: "none"}} color="inherit">{props.title? props.title: ""}</Typography>
+                <Show when={!!props.onClose}>
+                    <Button
+                        variant="text"
+                        disableRipple
+                        disableFocusRipple
+                        disableTouchRipple
+                        disableElevation
+                        color="inherit"
+                        sx={{minWidth: undefined, height: "24px", width: "24px"}}
+                        onClick={() => {
+                            if (props.onClose) {
+                                props.onClose({});
+                            }
+                        }}
+                    ><CloseIcon /></Button>
+                </Show>
+            </Box>
+            {props.children}
+        </Paper>
+    </Popper>;
+};
+
+export class OverlayWindowState {
+    open: Accessor<boolean>;
+    setOpen: Setter<boolean>;
+    title: Accessor<string | undefined>;
+    setTitle: Setter<string | undefined>;
+    position: Accessor<{x: number, y: number}>;
+    setPosition: Setter<{x: number, y: number}>;
+
+    constructor(defauleTitle?: string, defaultOpen = false, defaultPosition = {x: window.innerWidth / 2, y: window.innerHeight / 2}) {
+        const [open, setOpen] = createSignal<boolean>(defaultOpen);
+        this.open = open;
+        this.setOpen = setOpen;
+        const [title, setTitle] = createSignal<string | undefined>(defauleTitle);
+        this.title = title;
+        this.setTitle = setTitle;
+        const [position, setPosition] = createSignal<{x: number, y: number}>(defaultPosition);
+        this.position = position;
+        this.setPosition = setPosition;
+    }
+}
+
+export interface StatefulOverlayWindow {
+    id: string,
+    state: OverlayWindowState,
+    children?: JSX.Element,
+}
+
+export const StatefulOverlayWindow: Component<StatefulOverlayWindow> = (props) => {
+    return <OverlayWindow
+        id={props.id}
+        open={props.state.open()}
+        title={props.state.title()}
+        position={props.state.position()}
+        onPositionChanging={(pos) => props.state.setPosition(pos)}
+        onClose={() => props.state.setOpen(false)}
+    >{props.children}</OverlayWindow>;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,6 +1892,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solid-primitives/event-listener@npm:^2.1.0":
+  version: 2.2.0
+  resolution: "@solid-primitives/event-listener@npm:2.2.0"
+  dependencies:
+    "@solid-primitives/utils": ^1.2.0
+  peerDependencies:
+    solid-js: ^1.3.1
+  checksum: 9a564249cab33f69a23308e8d054ac7dfbaa16510d53e20d45e86600585e21fd5cb4b52df44183195855de6e2615d7d3774236e61d7abc03875179d09ee1be31
+  languageName: node
+  linkType: hard
+
 "@solid-primitives/raf@npm:^2.1.0":
   version: 2.1.0
   resolution: "@solid-primitives/raf@npm:2.1.0"
@@ -1903,7 +1914,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solid-primitives/utils@npm:^1.0.0":
+"@solid-primitives/resize-observer@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@solid-primitives/resize-observer@npm:2.0.2"
+  dependencies:
+    "@solid-primitives/event-listener": ^2.1.0
+    "@solid-primitives/rootless": ^1.1.0
+    "@solid-primitives/utils": ^2.1.0
+  peerDependencies:
+    solid-js: ^1.4.0
+  checksum: aaf29c664a4fdd68f0a6dc7381f62a6196f115fe8e094cc7c4be10fd6bd98699d4085a881f8fdf330110b8497bf7c54999bb07bd37f104b8a5c642dfaa3f5944
+  languageName: node
+  linkType: hard
+
+"@solid-primitives/rootless@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@solid-primitives/rootless@npm:1.1.1"
+  dependencies:
+    "@solid-primitives/utils": ^2.2.1
+  peerDependencies:
+    solid-js: ^1.3.1
+  checksum: c18b3304d3698d8f9a19ddb862be5a9083d15d8be5c2bd9761b44f92ab65c6c5cf665d0b5276d969a58f8734691c61b59bea105015c65e16485280508f6036ce
+  languageName: node
+  linkType: hard
+
+"@solid-primitives/utils@npm:^1.0.0, @solid-primitives/utils@npm:^1.2.0":
   version: 1.5.2
   resolution: "@solid-primitives/utils@npm:1.5.2"
   peerDependencies:
@@ -1912,7 +1947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solid-primitives/utils@npm:^2.2.1":
+"@solid-primitives/utils@npm:^2.1.0, @solid-primitives/utils@npm:^2.2.1":
   version: 2.2.1
   resolution: "@solid-primitives/utils@npm:2.2.1"
   peerDependencies:
@@ -5550,6 +5585,7 @@ __metadata:
     "@nanostores/solid": ^0.1.6
     "@size-limit/preset-app": ^7.0.8
     "@solid-primitives/raf": ^2.1.0
+    "@solid-primitives/resize-observer": ^2.0.2
     "@solid-primitives/utils": ^2.2.1
     "@suid/icons-material": ^0.2.5
     "@suid/material": ^0.4.3


### PR DESCRIPTION
The code design of `DrawBoard` clearly have a few flaws:
- No clear support of concurrent drawing.
- Only available under absolute-positioned layout.
- Mixed operations of data and view.

This PR rewrites the single `DrawBoard` to a data class `DrawBoard` and a component `DrawBoardView`.

- [x] `DrawBoard`
- [x] Base of new testing page
- [x] `DrawBoardView`: displaying content
- [ ] `DrawBoardView`: scrolling
- [ ] `DrawBoardView`: mouse drawing forwarding
- [ ] `DrawBoardView`: touch drawing forwarding
- [ ] Replace original `DrawBoard` with `DrawBoardView`